### PR TITLE
fix: increase puppeteer timeout and add optimizations for Raspberry Pi 3B

### DIFF
--- a/src/image-generator/image-generator.service.ts
+++ b/src/image-generator/image-generator.service.ts
@@ -172,13 +172,17 @@ export class ImageGeneratorService {
         },
         selector: '.wiki-card',
         transparent: true,
+        timeout: 90000,
         puppeteerArgs: {
           args: [
             '--no-sandbox',
             '--disable-setuid-sandbox',
             '--disable-dev-shm-usage',
+            '--disable-gpu',
+            '--no-zygote',
+            '--single-process',
           ],
-          timeout: 60000,
+          timeout: 90000,
         },
         beforeScreenshot: async (page) => {
           await page.setUserAgent(this.userAgent);


### PR DESCRIPTION
### Summary
This PR addresses the 30s timeout issue encountered when generating images on low-power hardware, specifically the Raspberry Pi 3B. The default 30-second timeout of `puppeteer-cluster` is often insufficient for Puppeteer to launch and render the page on such devices.

### Changes
- Increased the global `timeout` for `node-html-to-image` to 90 seconds.
- Updated `puppeteerArgs.timeout` to 90 seconds to match.
- Added Puppeteer flags to optimize performance and reduce resource usage on memory-constrained devices:
  - `--disable-gpu`: Disables hardware acceleration.
  - `--no-zygote`: Reduces process overhead.
  - `--single-process`: Runs Puppeteer in a single process to save memory.

### Related Issues
Closes #15