### PR TITLE
test: implement comprehensive unit tests and CI/CD automation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,7 +11,22 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm run test
+
   create-release:
+    needs: tests
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,6 @@
     "Streamable",
     "tlwg",
     "zenhei"
-  ]
+  ],
+  "github-actions.workflows.pinned.workflows": []
 }

--- a/src/common/utils/user-agent.spec.ts
+++ b/src/common/utils/user-agent.spec.ts
@@ -1,0 +1,44 @@
+import { getUserAgent } from './user-agent';
+import * as pkg from '../../../package.json';
+import * as axiosPkg from 'axios/package.json';
+
+describe('getUserAgent', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('should return a valid User-Agent string with environment email', () => {
+    process.env.WIKI_CONTACT_EMAIL = 'test@example.com';
+    const ua = getUserAgent();
+
+    expect(ua).toContain(pkg.name);
+    expect(ua).toContain(pkg.version);
+    expect(ua).toContain('test@example.com');
+    expect(ua).toContain(axiosPkg.name);
+    expect(ua).toContain(axiosPkg.version);
+  });
+
+  it('should fallback to "no-email-set" if WIKI_CONTACT_EMAIL is missing', () => {
+    delete process.env.WIKI_CONTACT_EMAIL;
+    const ua = getUserAgent();
+
+    expect(ua).toContain('no-email-set');
+  });
+
+  it('should follow the format: name/version (email) axios/version', () => {
+    process.env.WIKI_CONTACT_EMAIL = 'dev@wiki.bot';
+    const ua = getUserAgent();
+
+    const expectedRegex = new RegExp(
+      `${pkg.name}/${pkg.version} \\(dev@wiki\\.bot\\) ${axiosPkg.name}/${axiosPkg.version}`,
+    );
+    expect(ua).toMatch(expectedRegex);
+  });
+});

--- a/src/image-generator/image-generator.service.spec.ts
+++ b/src/image-generator/image-generator.service.spec.ts
@@ -1,5 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ImageGeneratorService } from './image-generator.service';
+import nodeHtmlToImage from 'node-html-to-image';
+import { Logger } from '@nestjs/common';
+
+// Mock node-html-to-image
+jest.mock('node-html-to-image');
 
 describe('ImageGeneratorService', () => {
   let service: ImageGeneratorService;
@@ -10,9 +15,214 @@ describe('ImageGeneratorService', () => {
     }).compile();
 
     service = module.get<ImageGeneratorService>(ImageGeneratorService);
+    jest.clearAllMocks();
+
+    // Suppress logs during tests
+    jest.spyOn(Logger.prototype, 'error').mockImplementation(() => {});
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => {});
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('generatePostImage', () => {
+    const mockData = {
+      title: 'Test Title',
+      extract_html: '<p>Test extract</p>',
+      imageUrl: 'http://example.com/image.jpg',
+      imageWidth: 1000,
+      imageHeight: 500,
+      theme: 'light' as const,
+    };
+
+    it('should generate an image and return a Buffer', async () => {
+      const mockBuffer = Buffer.from('mock image');
+      (nodeHtmlToImage as jest.Mock).mockResolvedValue(mockBuffer);
+
+      const result = await service.generatePostImage(mockData);
+
+      expect(result).toEqual(mockBuffer);
+      expect(nodeHtmlToImage).toHaveBeenCalled();
+    });
+
+    it('should detect landscape layout when width > height', async () => {
+      (nodeHtmlToImage as jest.Mock).mockResolvedValue(Buffer.from(''));
+
+      await service.generatePostImage({
+        ...mockData,
+        imageWidth: 1000,
+        imageHeight: 500,
+      });
+
+      expect(nodeHtmlToImage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.objectContaining({
+            isLandscape: true,
+          }),
+        }),
+      );
+    });
+
+    it('should detect portrait layout when width <= height', async () => {
+      (nodeHtmlToImage as jest.Mock).mockResolvedValue(Buffer.from(''));
+
+      await service.generatePostImage({
+        ...mockData,
+        imageWidth: 500,
+        imageHeight: 1000,
+      });
+
+      expect(nodeHtmlToImage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.objectContaining({
+            isLandscape: false,
+          }),
+        }),
+      );
+    });
+
+    it('should use smaller font size for long text', async () => {
+      (nodeHtmlToImage as jest.Mock).mockResolvedValue(Buffer.from(''));
+      const longText = 'a'.repeat(401);
+
+      await service.generatePostImage({
+        ...mockData,
+        extract_html: `<p>${longText}</p>`,
+      });
+
+      expect(nodeHtmlToImage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.objectContaining({
+            fontSize: '26px',
+          }),
+        }),
+      );
+    });
+
+    it('should use larger font size for short text', async () => {
+      (nodeHtmlToImage as jest.Mock).mockResolvedValue(Buffer.from(''));
+
+      await service.generatePostImage({
+        ...mockData,
+        extract_html: '<p>Short text</p>',
+      });
+
+      expect(nodeHtmlToImage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.objectContaining({
+            fontSize: '34px',
+          }),
+        }),
+      );
+    });
+
+    it('should use dark theme colors when specified', async () => {
+      (nodeHtmlToImage as jest.Mock).mockResolvedValue(Buffer.from(''));
+
+      await service.generatePostImage({
+        ...mockData,
+        theme: 'dark',
+      });
+
+      expect(nodeHtmlToImage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.objectContaining({
+            colors: expect.objectContaining({
+              cardBg: '#202122',
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('should handle extremely long titles', async () => {
+      (nodeHtmlToImage as jest.Mock).mockResolvedValue(Buffer.from(''));
+      const longTitle = 'A'.repeat(500);
+
+      await service.generatePostImage({
+        ...mockData,
+        title: longTitle,
+      });
+
+      expect(nodeHtmlToImage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.objectContaining({
+            title: longTitle,
+          }),
+        }),
+      );
+    });
+
+    it('should handle missing titles gracefully', async () => {
+      (nodeHtmlToImage as jest.Mock).mockResolvedValue(Buffer.from(''));
+
+      await service.generatePostImage({
+        ...mockData,
+        title: '',
+      });
+
+      expect(nodeHtmlToImage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.objectContaining({
+            title: '',
+          }),
+        }),
+      );
+    });
+
+    it('should handle extremely long descriptions', async () => {
+      (nodeHtmlToImage as jest.Mock).mockResolvedValue(Buffer.from(''));
+      const longExtract = 'B'.repeat(2000);
+
+      await service.generatePostImage({
+        ...mockData,
+        extract_html: `<p>${longExtract}</p>`,
+      });
+
+      expect(nodeHtmlToImage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.objectContaining({
+            fontSize: '26px', // Long text should trigger smaller font
+          }),
+        }),
+      );
+    });
+
+    it('should handle missing descriptions gracefully', async () => {
+      (nodeHtmlToImage as jest.Mock).mockResolvedValue(Buffer.from(''));
+
+      await service.generatePostImage({
+        ...mockData,
+        extract_html: '',
+      });
+
+      expect(nodeHtmlToImage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.objectContaining({
+            extract_html: '',
+            fontSize: '34px', // Empty text should trigger larger font
+          }),
+        }),
+      );
+    });
+
+    it('should handle missing imageUrl gracefully', async () => {
+      (nodeHtmlToImage as jest.Mock).mockResolvedValue(Buffer.from(''));
+
+      await service.generatePostImage({
+        ...mockData,
+        imageUrl: undefined,
+      });
+
+      expect(nodeHtmlToImage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.objectContaining({
+            imageUrl: undefined,
+          }),
+        }),
+      );
+    });
   });
 });

--- a/src/telegram/telegram.update.spec.ts
+++ b/src/telegram/telegram.update.spec.ts
@@ -1,0 +1,184 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TelegramUpdate } from './telegram.update';
+import { ConfigService } from '@nestjs/config';
+import { WikipediaService } from '../wikipedia/wikipedia.service';
+import { ImageGeneratorService } from '../image-generator/image-generator.service';
+import { Logger } from '@nestjs/common';
+
+describe('TelegramUpdate', () => {
+  let bot: TelegramUpdate;
+  let wikipediaService: WikipediaService;
+  let imageGeneratorService: ImageGeneratorService;
+  let configService: ConfigService;
+
+  const adminId = 12345;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TelegramUpdate,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn().mockImplementation((key: string) => {
+              if (key === 'TELEGRAM_ADMIN_CHAT_ID') return adminId.toString();
+              return null;
+            }),
+          },
+        },
+        {
+          provide: WikipediaService,
+          useValue: {
+            getRandomPage: jest.fn(),
+            getPageSummary: jest.fn(),
+          },
+        },
+        {
+          provide: ImageGeneratorService,
+          useValue: {
+            generatePostImage: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    bot = module.get<TelegramUpdate>(TelegramUpdate);
+    wikipediaService = module.get<WikipediaService>(WikipediaService);
+    imageGeneratorService = module.get<ImageGeneratorService>(
+      ImageGeneratorService,
+    );
+    configService = module.get<ConfigService>(ConfigService);
+
+    // Suppress logs during tests
+    jest.spyOn(Logger.prototype, 'error').mockImplementation(() => {});
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => {});
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
+    jest.spyOn(Logger.prototype, 'log').mockImplementation(() => {});
+  });
+
+  it('should be defined', () => {
+    expect(bot).toBeDefined();
+  });
+
+  describe('isAdmin', () => {
+    it('should return true if chatId matches adminId', () => {
+      const ctx = {
+        chat: { id: adminId },
+      } as any;
+      expect((bot as any).isAdmin(ctx)).toBe(true);
+    });
+
+    it('should return false and log warning if chatId does not match', () => {
+      const ctx = {
+        chat: { id: 99999 },
+        from: { id: 99999 },
+      } as any;
+      expect((bot as any).isAdmin(ctx)).toBe(false);
+    });
+  });
+
+  describe('onRandom', () => {
+    it('should process command if user is admin', async () => {
+      const ctx = {
+        chat: { id: adminId },
+        update: { update_id: 111 },
+        from: { id: adminId },
+        reply: jest.fn(),
+        replyWithPhoto: jest.fn(),
+      } as any;
+
+      const mockWikiData = {
+        title: 'Test',
+        extract_html: 'ext',
+        originalimage: { source: 'src', width: 1, height: 1 },
+      };
+      const mockImage = Buffer.from('img');
+
+      jest
+        .spyOn(wikipediaService, 'getRandomPage')
+        .mockResolvedValue(mockWikiData as any);
+      jest
+        .spyOn(imageGeneratorService, 'generatePostImage')
+        .mockResolvedValue(mockImage);
+
+      await bot.onRandom(ctx);
+
+      expect(ctx.reply).toHaveBeenCalledWith('Generating random page...');
+      expect(wikipediaService.getRandomPage).toHaveBeenCalledWith(111);
+      expect(imageGeneratorService.generatePostImage).toHaveBeenCalled();
+      expect(ctx.replyWithPhoto).toHaveBeenCalledWith({ source: mockImage });
+    });
+
+    it('should do nothing if user is not admin', async () => {
+      const ctx = {
+        chat: { id: 99999 },
+        from: { id: 99999 },
+        reply: jest.fn(),
+      } as any;
+
+      await bot.onRandom(ctx);
+
+      expect(ctx.reply).not.toHaveBeenCalled();
+      expect(wikipediaService.getRandomPage).not.toHaveBeenCalled();
+    });
+
+    it('should notify user on error', async () => {
+      const ctx = {
+        chat: { id: adminId },
+        update: { update_id: 111 },
+        from: { id: adminId },
+        reply: jest.fn(),
+      } as any;
+
+      jest
+        .spyOn(wikipediaService, 'getRandomPage')
+        .mockRejectedValue(new Error('Fail'));
+
+      await bot.onRandom(ctx);
+
+      expect(ctx.reply).toHaveBeenCalledWith('Error generating page.');
+    });
+  });
+
+  describe('onWiki', () => {
+    it('should ask for title if missing', async () => {
+      const ctx = {
+        chat: { id: adminId },
+        update: { update_id: 111 },
+        from: { id: adminId },
+        reply: jest.fn(),
+      } as any;
+
+      await bot.onWiki(ctx, '/wiki');
+
+      expect(ctx.reply).toHaveBeenCalledWith(
+        'Please provide a title. Usage: /wiki <title>',
+      );
+      expect(wikipediaService.getPageSummary).not.toHaveBeenCalled();
+    });
+
+    it('should search for title if provided', async () => {
+      const ctx = {
+        chat: { id: adminId },
+        update: { update_id: 111 },
+        from: { id: adminId },
+        reply: jest.fn(),
+        replyWithPhoto: jest.fn(),
+      } as any;
+
+      const mockWikiData = { title: 'T', extract_html: 'e' };
+      jest
+        .spyOn(wikipediaService, 'getPageSummary')
+        .mockResolvedValue(mockWikiData as any);
+      jest
+        .spyOn(imageGeneratorService, 'generatePostImage')
+        .mockResolvedValue(Buffer.from(''));
+
+      await bot.onWiki(ctx, '/wiki Rome');
+
+      expect(ctx.reply).toHaveBeenCalledWith('Searching for "Rome"...');
+      expect(wikipediaService.getPageSummary).toHaveBeenCalledWith('Rome', 111);
+      expect(ctx.replyWithPhoto).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/wikipedia/wikipedia.controller.spec.ts
+++ b/src/wikipedia/wikipedia.controller.spec.ts
@@ -1,18 +1,118 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { WikipediaController } from './wikipedia.controller';
+import { WikipediaService } from './wikipedia.service';
+import { ImageGeneratorService } from '../image-generator/image-generator.service';
+import { StreamableFile, Logger } from '@nestjs/common';
 
 describe('WikipediaController', () => {
   let controller: WikipediaController;
+  let wikipediaService: WikipediaService;
+  let imageGenerator: ImageGeneratorService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [WikipediaController],
+      providers: [
+        {
+          provide: WikipediaService,
+          useValue: {
+            getRandomPage: jest.fn(),
+            getPageSummary: jest.fn(),
+          },
+        },
+        {
+          provide: ImageGeneratorService,
+          useValue: {
+            generatePostImage: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     controller = module.get<WikipediaController>(WikipediaController);
+    wikipediaService = module.get<WikipediaService>(WikipediaService);
+    imageGenerator = module.get<ImageGeneratorService>(ImageGeneratorService);
+
+    // Suppress logs during tests
+    jest.spyOn(Logger.prototype, 'error').mockImplementation(() => {});
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => {});
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('getRandom', () => {
+    it('should call wikipediaService.getRandomPage', async () => {
+      const mockResult = { title: 'Test', extract: 'Test' };
+      jest
+        .spyOn(wikipediaService, 'getRandomPage')
+        .mockResolvedValue(mockResult as any);
+
+      const result = await controller.getRandom();
+
+      expect(result).toBe(mockResult);
+      expect(wikipediaService.getRandomPage).toHaveBeenCalled();
+    });
+  });
+
+  describe('getImagePreview', () => {
+    it('should generate an image preview from a random page', async () => {
+      const mockWikiData = {
+        title: 'Test',
+        extract_html: '<p>Test</p>',
+        originalimage: { source: 'url', width: 100, height: 100 },
+      };
+      const mockBuffer = Buffer.from('image');
+
+      jest
+        .spyOn(wikipediaService, 'getRandomPage')
+        .mockResolvedValue(mockWikiData as any);
+      jest
+        .spyOn(imageGenerator, 'generatePostImage')
+        .mockResolvedValue(mockBuffer);
+
+      const result = await controller.getImagePreview('light');
+
+      expect(result).toBeInstanceOf(StreamableFile);
+      expect(wikipediaService.getRandomPage).toHaveBeenCalled();
+      expect(imageGenerator.generatePostImage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: mockWikiData.title,
+          theme: 'light',
+        }),
+      );
+    });
+  });
+
+  describe('getImagePreviewByTitle', () => {
+    it('should generate an image preview for a specific title', async () => {
+      const title = 'Test_Title';
+      const mockWikiData = {
+        title: 'Test',
+        extract_html: '<p>Test</p>',
+        originalimage: { source: 'url', width: 100, height: 100 },
+      };
+      const mockBuffer = Buffer.from('image');
+
+      jest
+        .spyOn(wikipediaService, 'getPageSummary')
+        .mockResolvedValue(mockWikiData as any);
+      jest
+        .spyOn(imageGenerator, 'generatePostImage')
+        .mockResolvedValue(mockBuffer);
+
+      const result = await controller.getImagePreviewByTitle(title, 'dark');
+
+      expect(result).toBeInstanceOf(StreamableFile);
+      expect(wikipediaService.getPageSummary).toHaveBeenCalledWith(title);
+      expect(imageGenerator.generatePostImage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: mockWikiData.title,
+          theme: 'dark',
+        }),
+      );
+    });
   });
 });

--- a/src/wikipedia/wikipedia.service.spec.ts
+++ b/src/wikipedia/wikipedia.service.spec.ts
@@ -1,18 +1,136 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { WikipediaService } from './wikipedia.service';
+import { WikipediaService, WikiResponse } from './wikipedia.service';
+import { HttpService } from '@nestjs/axios';
+import { of, throwError } from 'rxjs';
+import { InternalServerErrorException, Logger } from '@nestjs/common';
 
 describe('WikipediaService', () => {
   let service: WikipediaService;
+  let httpService: HttpService;
+
+  const mockWikiResponse: WikiResponse = {
+    title: 'Test Page',
+    extract: 'This is a test extract.',
+    extract_html: '<p>This is a test extract.</p>',
+    originalimage: {
+      source: 'https://example.com/image.jpg',
+      width: 100,
+      height: 100,
+    },
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [WikipediaService],
+      providers: [
+        WikipediaService,
+        {
+          provide: HttpService,
+          useValue: {
+            get: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     service = module.get<WikipediaService>(WikipediaService);
+    httpService = module.get<HttpService>(HttpService);
+
+    // Suppress logs during tests
+    jest.spyOn(Logger.prototype, 'error').mockImplementation(() => {});
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => {});
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('getRandomPage', () => {
+    it('should return a random page summary on success', async () => {
+      jest.spyOn(httpService, 'get').mockReturnValue(
+        of({
+          data: mockWikiResponse,
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config: {} as any,
+        }),
+      );
+
+      const result = await service.getRandomPage('test-trace-id');
+
+      expect(result).toEqual(mockWikiResponse);
+      expect(httpService.get).toHaveBeenCalledWith(
+        'https://en.wikipedia.org/api/rest_v1/page/random/summary',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'User-Agent': expect.any(String),
+            Accept: 'application/json',
+          }),
+        }),
+      );
+    });
+
+    it('should throw InternalServerErrorException if the API call fails', async () => {
+      jest
+        .spyOn(httpService, 'get')
+        .mockReturnValue(throwError(() => new Error('API Error')));
+
+      await expect(service.getRandomPage('test-trace-id')).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+
+    it('should clean the extract text', async () => {
+      const responseWithMessyText = {
+        ...mockWikiResponse,
+        extract: '  This   is  messy  text.  ',
+      };
+      jest.spyOn(httpService, 'get').mockReturnValue(
+        of({
+          data: responseWithMessyText,
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config: {} as any,
+        }),
+      );
+
+      const result = await service.getRandomPage();
+      expect(result.extract).toBe('This is messy text.');
+    });
+  });
+
+  describe('getPageSummary', () => {
+    it('should return a page summary by title on success', async () => {
+      const title = 'Test_Page';
+      jest.spyOn(httpService, 'get').mockReturnValue(
+        of({
+          data: mockWikiResponse,
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config: {} as any,
+        }),
+      );
+
+      const result = await service.getPageSummary(title, 'test-trace-id');
+
+      expect(result).toEqual(mockWikiResponse);
+      expect(httpService.get).toHaveBeenCalledWith(
+        `https://en.wikipedia.org/api/rest_v1/page/summary/${title}`,
+        expect.any(Object),
+      );
+    });
+
+    it('should throw InternalServerErrorException if the API call fails', async () => {
+      jest
+        .spyOn(httpService, 'get')
+        .mockReturnValue(throwError(() => new Error('API Error')));
+
+      await expect(
+        service.getPageSummary('Invalid_Page', 'test-trace-id'),
+      ).rejects.toThrow(InternalServerErrorException);
+    });
   });
 });


### PR DESCRIPTION
- Add unit tests for WikipediaService, ImageGeneratorService, and WikipediaController
- Implement tests for Telegram bot logic (TelegramUpdate)
- Add utility tests for getUserAgent function
- Cover edge cases: long titles/descriptions and missing images
- Create GitHub Actions workflow for automated testing (CI)
- Update docker-publish workflow to require passing tests before release

close: #10