### PR TITLE
feat(telegram): add /status command and enhance /start (#23)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "node-html-to-image": "^5.0.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.2",
+        "systeminformation": "^5.30.7",
         "telegraf": "^4.16.3",
         "winston": "^3.19.0",
         "winston-daily-rotate-file": "^5.0.0"
@@ -9881,6 +9882,32 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/systeminformation": {
+      "version": "5.30.7",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.30.7.tgz",
+      "integrity": "sha512-33B/cftpaWdpvH+Ho9U1b08ss8GQuLxrWHelbJT1yw4M48Taj8W3ezcPuaLoIHZz5V6tVHuQPr5BprEfnBLBMw==",
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32",
+        "freebsd",
+        "openbsd",
+        "netbsd",
+        "sunos",
+        "android"
+      ],
+      "bin": {
+        "systeminformation": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "Buy me a coffee",
+        "url": "https://www.buymeacoffee.com/systeminfo"
       }
     },
     "node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "node-html-to-image": "^5.0.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
+    "systeminformation": "^5.30.7",
     "telegraf": "^4.16.3",
     "winston": "^3.19.0",
     "winston-daily-rotate-file": "^5.0.0"

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { WikipediaModule } from './wikipedia/wikipedia.module';
 import { ImageGeneratorModule } from './image-generator/image-generator.module';
+import { SystemInfoModule } from './system-info/system-info.module';
 import { TelegramModule } from './telegram/telegram.module';
+import { WikipediaModule } from './wikipedia/wikipedia.module';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { TelegramModule } from './telegram/telegram.module';
     WikipediaModule,
     ImageGeneratorModule,
     TelegramModule,
+    SystemInfoModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/system-info/system-info.module.ts
+++ b/src/system-info/system-info.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { SystemInfoService } from './system-info.service';
+
+@Module({
+  providers: [SystemInfoService],
+  exports: [SystemInfoService],
+})
+export class SystemInfoModule {}

--- a/src/system-info/system-info.service.ts
+++ b/src/system-info/system-info.service.ts
@@ -1,0 +1,79 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as si from 'systeminformation';
+import * as pkg from '../../package.json';
+
+@Injectable()
+export class SystemInfoService {
+  private readonly logger = new Logger(SystemInfoService.name);
+
+  async getSystemStatus() {
+    try {
+      const currentLoad = await si.currentLoad();
+      const [cpu, mem, osInfo, time] = await Promise.all([
+        si.cpu(),
+        si.mem(),
+        si.osInfo(),
+        si.time(),
+      ]);
+
+      const temp = await si.cpuTemperature();
+
+      return {
+        botVersion: pkg.version,
+        osInfo: {
+          platform: osInfo.platform,
+          distro: osInfo.distro,
+          release: osInfo.release,
+          arch: osInfo.arch,
+        },
+        cpu: {
+          manufacturer: cpu.manufacturer,
+          brand: cpu.brand,
+          speed: cpu.speed,
+          cores: cpu.cores,
+          load: currentLoad.currentLoad.toFixed(2),
+          temp: temp.main ? `${temp.main}°C` : 'N/A',
+        },
+        memory: {
+          total: this.formatBytes(mem.total),
+          free: this.formatBytes(mem.free),
+          used: this.formatBytes(mem.used),
+          active: this.formatBytes(mem.active),
+          available: this.formatBytes(mem.available),
+        },
+        uptime: this.formatUptime(time.uptime),
+        botUptime: this.formatUptime(process.uptime()),
+      };
+    } catch (e) {
+      this.logger.error('Failed to get system status', e.stack);
+      throw e;
+    }
+  }
+
+  private formatBytes(bytes: number, decimals = 2) {
+    if (bytes === 0) return '0 Bytes';
+
+    const k = 1024;
+    const dm = decimals < 0 ? 0 : decimals;
+    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
+  }
+
+  private formatUptime(seconds: number) {
+    const days = Math.floor(seconds / (3600 * 24));
+    const hours = Math.floor((seconds % (3600 * 24)) / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+    const s = Math.floor(seconds % 60);
+
+    const parts: string[] = [];
+    if (days > 0) parts.push(`${days}d`);
+    if (hours > 0) parts.push(`${hours}h`);
+    if (minutes > 0) parts.push(`${minutes}m`);
+    parts.push(`${s}s`);
+
+    return parts.join(' ');
+  }
+}

--- a/src/telegram/telegram.module.ts
+++ b/src/telegram/telegram.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TelegrafModule } from 'nestjs-telegraf';
 import { ImageGeneratorModule } from '../image-generator/image-generator.module';
+import { SystemInfoModule } from '../system-info/system-info.module';
 import { WikipediaModule } from '../wikipedia/wikipedia.module';
 import { TelegramUpdate } from './telegram.update';
 
@@ -16,6 +17,7 @@ import { TelegramUpdate } from './telegram.update';
     }),
     WikipediaModule,
     ImageGeneratorModule,
+    SystemInfoModule,
   ],
   providers: [TelegramUpdate],
 })


### PR DESCRIPTION
## Description

This PR introduces a new `/status` command to the Telegram bot, allowing administrators to monitor the system's health in real-time. It also enhances the `/start` command with a better welcome message and a list of available commands.

Key changes:
- **Implemented [SystemInfoService](cci:2://file:///c:/Users/Alessandro/Documents/Projects/wiki-bot/src/system-info/system-info.service.ts:4:0-78:1)**: Uses the `systeminformation` library to fetch CPU load, temperature, memory usage, OS details, and uptime.
- **Added `/status` command**: Displays the gathered system metrics.
- **Added "Bot Uptime"**: solved the issue of incorrect system uptime on Windows (due to Fast Startup) by displaying the actual runtime of the bot process.
- **Enhanced `/start` command**: Now provides a formatted welcome message with a clear list of commands.
- **Fixed `systeminformation` dependency**: Ensured all necessary packages and types are installed.

Closes #23

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

I verified the changes by running the bot locally on Windows 11.

- [x] Manual test
    - Verified `/status` returns correct OS, CPU, RAM, and Uptime info.
    - Verified "Bot Uptime" resets on restart while "System Uptime" persists (correct behavior for Windows Fast Startup).
    - Verified `/start` displays the new welcome message with emojis.
- [ ] Unit tests
    - `npm run build` passes successfully.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes