### PR TITLE
feat(telegram): implement image approval workflow and deduplication (#29)

### DIFF
--- a/src/wikipedia/wikipedia.service.ts
+++ b/src/wikipedia/wikipedia.service.ts
@@ -109,6 +109,16 @@ export class WikipediaService {
     );
   }
 
+  /**
+   * Checks if a page is already present in the history.
+   */
+  async isPageInHistory(pageId: string | number): Promise<boolean> {
+    const exists = await this.wikiHistoryRepository.findOne({
+      where: { pageId: pageId.toString() },
+    });
+    return !!exists;
+  }
+
   /** Saves a page to the history database. */
   async saveToHistory(
     pageId: string | number,


### PR DESCRIPTION
## Description

This PR implements a centralized image approval workflow and content deduplication for the Telegram bot, resolving requested features for better editorial control and efficiency.

Key changes include:
- **Image Approval Workflow**: Integrated an inline keyboard with "Accept" and "Reject" buttons for every generated Wikipedia image. 
- **Deduplication Logic**: Updated the `/wiki` command to check the WikiHistory database. If an article has already been approved, the bot now generates a "Preview" image without action buttons.
- **Uniform Messaging**: Standardized the status messages across all states (Approved, Rejected, Already in History) to include consistent labeling and the Wikipedia page title:
    - ✅ **Approved:** [Title]
    - ❌ **Rejected:** [Title]
    - ⚠️ **Already in history:** [Title]
- **Robust Persistence**: Approval actions are now stateless, extracting data from callback queries to ensure reliability across bot restarts.

Closes #29

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] **Manual test**: Verified the full flow via Telegram (Accepting/Rejecting articles and attempting to re-pull existing items to trigger the "Already in history" state).
- [x] **Unit tests**: Updated telegram.update.spec.ts with 18 tests covering the new action handlers, deduplication logic, and caption formatting.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes