### PR TITLE
fix(system-info): report accurate RAM usage by excluding buffers and cache (#33)

### DIFF
--- a/src/system-info/system-info.service.ts
+++ b/src/system-info/system-info.service.ts
@@ -37,7 +37,7 @@ export class SystemInfoService {
         memory: {
           total: this.formatBytes(mem.total),
           free: this.formatBytes(mem.free),
-          used: this.formatBytes(mem.used),
+          used: this.formatBytes(mem.total - mem.available),
           active: this.formatBytes(mem.active),
           available: this.formatBytes(mem.available),
         },


### PR DESCRIPTION
## Description

This PR fixes the misleading RAM usage reporting in the `/status` command. On Linux systems, the previous implementation counted disk buffers and cache as "used" memory, often leading to reports of high memory exhaustion even when actual memory pressure was low. 

The calculation has been updated to use `total - available`, which aligns with the behavior of standard system tools like `free -m`.

Closes #33

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

The changes were verified by running the bot locally and ensuring the memory metrics are correctly computed from the `systeminformation` data.

- [x] Manual test
- [x] Unit tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

